### PR TITLE
Fix clearSearch method

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-8.7.0-datadope.2
+8.7.0-datadope.3

--- a/src/App.vue
+++ b/src/App.vue
@@ -727,7 +727,7 @@ export default {
       this.query = null
       this.$store.dispatch('alerts/updateQuery', {})
       this.$router.push({
-        query: { ...this.$router.query, q: undefined },
+        query: { ...this.$router.query, q: {} },
         hash: this.$store.getters['alerts/getHash']
       })
       this.refresh()


### PR DESCRIPTION
The query variable was set as undefinded in the alert store, this generated an erroneous query when refreshing the alerts. Set query var as an empty object, initial state of the variable.